### PR TITLE
:technologist: PTS-5 - Add standard issues and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Please use this template if you are reporting a bug
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+# Bug report
+## Expected behavior
+<!--- What should the code be doing? -->
+
+## Actual behavior
+<!--- What does the code actually does? -->
+
+## Steps to reproduce the problem
+<!--- Please show us a minimal way to reproduce the issue. -->
+  1.
+  1.
+  1.
+
+## Specifications
+<!--- Please include all relevant context to the bug. -->
+  - Version:
+  - Platform:
+  - Subsystem:
+
+
+<!--- Attaching a log file, a screenshot, or anything to document your bug is mandatory in almost all cases. Please don't forget to attach your log. -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Please use this template if you are submitting a feature request
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+# Feature request
+
+## Feature description
+<!--- Explain what your feature should do. -->
+
+## Feature necessity
+<!--- Explain why your feature is needed. -->
+
+## Additional context
+<!--- Please provide any context that would help us better understand your need. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+# Pull Request
+
+<!--- Please specify if your PR fixes an issue, or contributes to fixing an issue -->
+Fixes #
+
+## Proposed Changes
+<!--- Please list the changes introduced by your code -->
+  -
+  -
+  -


### PR DESCRIPTION
Add standard templates for issues and pull requests. They were copy-pasted from our git law book.